### PR TITLE
댓글 등록, 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/fasttime/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentController.java
@@ -1,0 +1,54 @@
+package com.fasttime.domain.comment.controller;
+
+import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
+import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
+import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;
+import com.fasttime.domain.comment.service.CommentService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/v1/comment")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/create")
+    public ModelAndView create(@Valid @RequestBody CreateCommentRequest createCommentRequest,
+        ModelAndView mv) {
+        log.info("CreateCommentRequest: " + createCommentRequest);
+        mv.setStatus(HttpStatus.CREATED);
+        mv.addObject(commentService.createComment(createCommentRequest));
+        mv.setViewName("registerCommentSuccess");
+        return mv;
+    }
+
+    @PostMapping("/delete")
+    public ModelAndView delete(@Valid @RequestBody DeleteCommentRequest deleteCommentRequest,
+        ModelAndView mv) {
+        log.info("DeleteCommentRequest: " + deleteCommentRequest);
+        mv.setStatus(HttpStatus.OK);
+        mv.addObject(commentService.deleteComment(deleteCommentRequest));
+        mv.setViewName("removeCommentSuccess");
+        return mv;
+    }
+
+    @PostMapping("/update")
+    public ModelAndView update(@Valid @RequestBody UpdateCommentRequest updateCommentRequest,
+        ModelAndView mv) {
+        log.info("UpdateCommentRequest: " + updateCommentRequest);
+        mv.setStatus(HttpStatus.OK);
+        mv.addObject(commentService.updateComment(updateCommentRequest));
+        mv.setViewName("updateCommentSuccess");
+        return mv;
+    }
+}

--- a/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
@@ -1,0 +1,57 @@
+package com.fasttime.domain.comment.controller;
+
+import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
+import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
+import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;
+import com.fasttime.domain.comment.service.CommentService;
+import java.util.HashMap;
+import java.util.Map;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/comment")
+public class CommentRestController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/create")
+    public ResponseEntity<Map<String, Object>> create(
+        @Valid @RequestBody CreateCommentRequest createCommentRequest) {
+        log.info("CreateCommentRequest: " + createCommentRequest);
+        Map<String, Object> message = new HashMap<>();
+        message.put("status", 201);
+        message.put("data", commentService.createComment(createCommentRequest));
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(message);
+    }
+
+    @PostMapping("/delete")
+    public ResponseEntity<Map<String, Object>> delete(
+        @Valid @RequestBody DeleteCommentRequest deleteCommentRequest) {
+        log.info("DeleteCommentRequest: " + deleteCommentRequest);
+        Map<String, Object> message = new HashMap<>();
+        message.put("status", 200);
+        message.put("data", commentService.deleteComment(deleteCommentRequest));
+        return ResponseEntity.status(HttpStatus.OK).body(message);
+    }
+
+    @PostMapping("/update")
+    public ResponseEntity<Map<String, Object>> update(
+        @Valid @RequestBody UpdateCommentRequest updateCommentRequest) {
+        log.info("UpdateCommentRequest: " + updateCommentRequest);
+        Map<String, Object> message = new HashMap<>();
+        message.put("status", 200);
+        message.put("data", commentService.updateComment(updateCommentRequest));
+        return ResponseEntity.status(HttpStatus.OK).body(message);
+    }
+}

--- a/src/main/java/com/fasttime/domain/comment/controller/CommentRestControllerAdvice.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentRestControllerAdvice.java
@@ -1,0 +1,47 @@
+package com.fasttime.domain.comment.controller;
+
+import com.fasttime.domain.comment.exception.NotFoundException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class CommentRestControllerAdvice {
+
+    @ExceptionHandler
+    public ResponseEntity<?> notFoundException(NotFoundException e) {
+        log.error("NotFoundException: " + e.getMessage());
+        Map<String, Object> errorMessage = new HashMap<>();
+        errorMessage.put("status", 404);
+        errorMessage.put("error", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(MediaType.APPLICATION_JSON)
+            .body(errorMessage);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<?> bindException(BindException e) {
+        log.error("BindException: " + e.getMessage());
+        Map<String, Object> errorMessage = new HashMap<>();
+        errorMessage.put("status", 400);
+        errorMessage.put("error", e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(MediaType.APPLICATION_JSON)
+            .body(errorMessage);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<?> illegalArgException(IllegalArgumentException e) {
+        log.error("IllegalArgumentException: " + e.getMessage());
+        Map<String, Object> errorMessage = new HashMap<>();
+        errorMessage.put("status", 400);
+        errorMessage.put("error", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(MediaType.APPLICATION_JSON)
+            .body(errorMessage);
+    }
+}

--- a/src/main/java/com/fasttime/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/fasttime/domain/comment/dto/CommentDto.java
@@ -1,0 +1,17 @@
+package com.fasttime.domain.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+public class CommentDto {
+
+    private Long id;
+    private Long postId;
+    private Long memberId;
+    private String content;
+    private boolean anonymity;
+    private Long parentCommentId;
+}

--- a/src/main/java/com/fasttime/domain/comment/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/fasttime/domain/comment/dto/request/CreateCommentRequest.java
@@ -1,0 +1,31 @@
+package com.fasttime.domain.comment.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateCommentRequest {
+
+    @NotNull(message = "게시글 ID를 입력하세요.")
+    private Long postId;
+
+    @NotNull(message = "회원 ID를 입력하세요.")
+    private Long memberId;
+
+    @NotBlank(message = "댓글 내용을 입력하세요.")
+    @Size(min = 1, max = 100, message = "내용을 100자 이내로 입력하세요.")
+    private String content;
+
+    @NotNull(message = "익명 여부를 선택하세요.")
+    private Boolean anonymity;
+
+    private Long parentCommentId;
+}

--- a/src/main/java/com/fasttime/domain/comment/dto/request/DeleteCommentRequest.java
+++ b/src/main/java/com/fasttime/domain/comment/dto/request/DeleteCommentRequest.java
@@ -1,0 +1,17 @@
+package com.fasttime.domain.comment.dto.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteCommentRequest {
+
+    @NotNull(message = "삭제할 댓글 ID를 입력하세요.")
+    Long id;
+}

--- a/src/main/java/com/fasttime/domain/comment/dto/request/UpdateCommentRequest.java
+++ b/src/main/java/com/fasttime/domain/comment/dto/request/UpdateCommentRequest.java
@@ -1,0 +1,20 @@
+package com.fasttime.domain.comment.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateCommentRequest {
+
+    @NotNull(message = "수정할 댓글 ID를 입력하세요.") Long id;
+
+    @NotBlank(message = "댓글 내용을 입력하세요.") @Size(min = 1, max = 100, message = "내용을 100자 이내로 입력하세요.") String content;
+}

--- a/src/main/java/com/fasttime/domain/comment/entity/Comment.java
+++ b/src/main/java/com/fasttime/domain/comment/entity/Comment.java
@@ -1,8 +1,10 @@
 package com.fasttime.domain.comment.entity;
 
+import com.fasttime.domain.comment.dto.CommentDto;
 import com.fasttime.domain.member.entity.Member;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.global.common.BaseTimeEntity;
+import java.time.LocalDateTime;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -10,6 +12,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,4 +40,33 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "comment_parent_id")
     @ManyToOne
     private Comment parentComment;
+
+    @Builder
+    public Comment(Long id, Post post, Member member, String content, boolean anonymity,
+        Comment parentComment) {
+        this.id = id;
+        this.post = post;
+        this.member = member;
+        this.content = content;
+        this.anonymity = anonymity;
+        this.parentComment = parentComment;
+    }
+
+    public void deleteComment() {
+        this.delete(LocalDateTime.now());
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public CommentDto toDto() {
+        Long parentCommentId = null;
+        if (this.parentComment != null) {
+            parentCommentId = this.parentComment.getId();
+        }
+        return CommentDto.builder().id(this.id).postId(this.post.getId())
+            .memberId(this.member.getId()).content(this.content).anonymity(this.anonymity)
+            .parentCommentId(parentCommentId).build();
+    }
 }

--- a/src/main/java/com/fasttime/domain/comment/exception/NotFoundException.java
+++ b/src/main/java/com/fasttime/domain/comment/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package com.fasttime.domain.comment.exception;
+
+public class NotFoundException extends RuntimeException {
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/fasttime/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/fasttime/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.fasttime.domain.comment.repository;
+
+import com.fasttime.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/fasttime/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fasttime/domain/comment/service/CommentService.java
@@ -1,0 +1,81 @@
+package com.fasttime.domain.comment.service;
+
+import com.fasttime.domain.comment.dto.CommentDto;
+import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
+import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
+import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;
+import com.fasttime.domain.comment.entity.Comment;
+import com.fasttime.domain.comment.exception.NotFoundException;
+import com.fasttime.domain.comment.repository.CommentRepository;
+import com.fasttime.domain.member.entity.Member;
+import com.fasttime.domain.member.repository.MemberRepository;
+import com.fasttime.domain.post.entity.Post;
+import com.fasttime.domain.post.repository.PostRepository;
+import java.util.Optional;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    public CommentDto createComment(CreateCommentRequest req) {
+        // TODO : post, member 각각 postService, memberService 를 통해 읽어 온다.
+        Optional<Post> post = postRepository.findById(req.getPostId());
+        Optional<Member> member = memberRepository.findById(req.getMemberId());
+        Comment parentComment = null;
+        // 대댓글인 경우
+        if (req.getParentCommentId() != null) {
+            Optional<Comment> Comment = commentRepository.findById(req.getParentCommentId());
+            if (Comment.isEmpty()) {
+                throw new NotFoundException("존재하지 않는 댓글입니다.");
+            } else {
+                parentComment = Comment.get();
+            }
+        }
+        if (post.isEmpty()) {
+            throw new NotFoundException("존재하지 않는 게시글입니다.");
+        } else if (member.isEmpty()) {
+            throw new NotFoundException("존재하지 않는 회원입니다.");
+        } else {
+            return commentRepository.save(
+                Comment.builder().post(post.get()).member(member.get()).content(req.getContent())
+                    .anonymity(req.getAnonymity()).parentComment(parentComment).build()).toDto();
+        }
+    }
+
+    public CommentDto getComment(Long id) {
+        Optional<Comment> comment = commentRepository.findById(id);
+        if (comment.isEmpty()) {
+            throw new NotFoundException("존재하지 않는 댓글입니다.");
+        } else {
+            return comment.get().toDto();
+        }
+    }
+
+    public CommentDto deleteComment(DeleteCommentRequest req) {
+        Optional<Comment> comment = commentRepository.findById(req.getId());
+        if (comment.isEmpty()) {
+            throw new NotFoundException("존재하지 않는 댓글입니다.");
+        } else {
+            comment.get().deleteComment();
+            return comment.get().toDto();
+        }
+    }
+
+    public CommentDto updateComment(UpdateCommentRequest req) {
+        Optional<Comment> comment = commentRepository.findById(req.getId());
+        if (comment.isEmpty()) {
+            throw new NotFoundException("존재하지 않는 댓글입니다.");
+        } else {
+            comment.get().updateContent(req.getContent());
+        }
+        return comment.get().toDto();
+    }
+}

--- a/src/test/java/com/fasttime/domain/comment/controller/CommentRestControllerTest.java
+++ b/src/test/java/com/fasttime/domain/comment/controller/CommentRestControllerTest.java
@@ -1,0 +1,339 @@
+package com.fasttime.domain.comment.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasttime.domain.comment.dto.CommentDto;
+import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
+import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
+import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;
+import com.fasttime.domain.comment.service.CommentService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CommentRestController.class)
+public class CommentRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    CommentService commentService;
+
+    @Nested
+    @DisplayName("create()은")
+    class Context_create {
+
+        @Test
+        @DisplayName("댓글을 등록할 수 있다.")
+        void _willSuccess() throws Exception {
+
+            // given
+            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
+                .content("test").anonymity(false).parentCommentId(null).build();
+            CommentDto commentDto = CommentDto.builder().id(0L).postId(0L).memberId(0L)
+                .content("test").anonymity(false).parentCommentId(null).build();
+            given(commentService.createComment(any(CreateCommentRequest.class))).willReturn(
+                commentDto);
+            String json = new ObjectMapper().writeValueAsString(request);
+
+            // when, then
+            mockMvc.perform(post("/api/v1/comment/create").content(json)
+                    .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.id").exists())
+                .andExpect(jsonPath("$.data.postId").exists())
+                .andExpect(jsonPath("$.data.memberId").exists())
+                .andExpect(jsonPath("$.data.content").exists())
+                .andExpect(jsonPath("$.data.anonymity").exists())
+                .andExpect(jsonPath("$.data.parentCommentId").isEmpty()).andDo(print());
+            verify(commentService, times(1)).createComment(any(CreateCommentRequest.class));
+        }
+
+        @Nested
+        @DisplayName("postId가 ")
+        class Element_postId {
+
+            @Test
+            @DisplayName("null일 경우 댓글을 등록할 수 없다.")
+            void null_willFail() throws Exception {
+
+                // given
+                CreateCommentRequest request = CreateCommentRequest.builder().postId(null)
+                    .memberId(0L).content("test").anonymity(false).parentCommentId(null).build();
+                CommentDto commentDto = CommentDto.builder().id(0L).postId(0L).memberId(0L)
+                    .content("test").anonymity(false).parentCommentId(null).build();
+                given(commentService.createComment(any(CreateCommentRequest.class))).willReturn(
+                    commentDto);
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(post("/api/v1/comment/create").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                verify(commentService, never()).createComment(any(CreateCommentRequest.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("memberId가 ")
+        class Element_memberId {
+
+            @Test
+            @DisplayName("null일 경우 댓글을 등록할 수 없다.")
+            void null_willFail() throws Exception {
+
+                // given
+                CreateCommentRequest request = CreateCommentRequest.builder().postId(0L)
+                    .memberId(null).content("test").anonymity(false).parentCommentId(null).build();
+                CommentDto commentDto = CommentDto.builder().id(0L).postId(0L).memberId(0L)
+                    .content("test").anonymity(false).parentCommentId(null).build();
+                given(commentService.createComment(any(CreateCommentRequest.class))).willReturn(
+                    commentDto);
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(post("/api/v1/comment/create").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                verify(commentService, never()).createComment(any(CreateCommentRequest.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("content가 ")
+        class Element_content {
+
+            @Test
+            @DisplayName("null일 경우 댓글을 등록할 수 없다.")
+            void null_willFail() throws Exception {
+
+                // given
+                CreateCommentRequest request = CreateCommentRequest.builder().postId(0L)
+                    .memberId(0L).content(null).anonymity(false).parentCommentId(null).build();
+                CommentDto commentDto = CommentDto.builder().id(0L).postId(0L).memberId(0L)
+                    .content("test").anonymity(false).parentCommentId(null).build();
+                given(commentService.createComment(any(CreateCommentRequest.class))).willReturn(
+                    commentDto);
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // whCreate
+                mockMvc.perform(post("/api/v1/comment/create").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                verify(commentService, never()).createComment(any(CreateCommentRequest.class));
+            }
+
+            @Test
+            @DisplayName("빈 칸일 경우 댓글을 등록할 수 없다.")
+            void blank_willFail() throws Exception {
+
+                // given
+                CreateCommentRequest request = CreateCommentRequest.builder().postId(0L)
+                    .memberId(0L).content(" ").anonymity(false).parentCommentId(null).build();
+                CommentDto commentDto = CommentDto.builder().id(0L).postId(0L).memberId(0L)
+                    .content("test").anonymity(false).parentCommentId(null).build();
+                given(commentService.createComment(any(CreateCommentRequest.class))).willReturn(
+                    commentDto);
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(post("/api/v1/comment/create").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                verify(commentService, never()).createComment(any(CreateCommentRequest.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("anonymity가 ")
+        class Element_anonymity {
+
+            @Test
+            @DisplayName("null일 경우 댓글을 등록할 수 없다.")
+            void null_willFail() throws Exception {
+
+                // given
+                CreateCommentRequest request = CreateCommentRequest.builder().postId(0L)
+                    .memberId(0L).content("test").anonymity(null).parentCommentId(null).build();
+                CommentDto commentDto = CommentDto.builder().id(0L).postId(0L).memberId(0L)
+                    .content("test").anonymity(false).parentCommentId(null).build();
+                given(commentService.createComment(any(CreateCommentRequest.class))).willReturn(
+                    commentDto);
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(post("/api/v1/comment/create").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                verify(commentService, never()).createComment(any(CreateCommentRequest.class));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("delete()은 ")
+    class Context_delete {
+
+        @Test
+        @DisplayName("댓글을 삭제할 수 있다.")
+        void _willSuccess() throws Exception {
+
+            // given
+            DeleteCommentRequest request = DeleteCommentRequest.builder().id(0L).build();
+            CommentDto commentDto = CommentDto.builder().id(0L).postId(0L).memberId(0L)
+                .content("test").anonymity(false).parentCommentId(null).build();
+            given(commentService.deleteComment(any(DeleteCommentRequest.class))).willReturn(
+                commentDto);
+            String json = new ObjectMapper().writeValueAsString(request);
+
+            // when, then
+            mockMvc.perform(post("/api/v1/comment/delete").content(json)
+                    .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").exists())
+                .andExpect(jsonPath("$.data.postId").exists())
+                .andExpect(jsonPath("$.data.memberId").exists())
+                .andExpect(jsonPath("$.data.content").exists())
+                .andExpect(jsonPath("$.data.anonymity").exists())
+                .andExpect(jsonPath("$.data.parentCommentId").isEmpty()).andDo(print());
+            verify(commentService, times(1)).deleteComment(any(DeleteCommentRequest.class));
+        }
+
+        @Nested
+        @DisplayName("id가 ")
+        class Element_id {
+
+            @Test
+            @DisplayName("null일 경우 댓글을 삭제할 수 없다.")
+            void null_willFail() throws Exception {
+
+                // given
+                DeleteCommentRequest request = DeleteCommentRequest.builder().id(null).build();
+                CommentDto commentDto = CommentDto.builder().id(0L).postId(0L).memberId(0L)
+                    .content("test").anonymity(false).parentCommentId(null).build();
+                given(commentService.deleteComment(any(DeleteCommentRequest.class))).willReturn(
+                    commentDto);
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(post("/api/v1/comment/delete").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                verify(commentService, never()).deleteComment(any(DeleteCommentRequest.class));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("update()는 ")
+    class Context_update {
+
+        @Test
+        @DisplayName("댓글을 수정할 수 있다.")
+        void _willSuccess() throws Exception {
+
+            // given
+            UpdateCommentRequest request = UpdateCommentRequest.builder().id(0L).content("modified")
+                .build();
+            CommentDto commentDto = CommentDto.builder().id(0L).postId(0L).memberId(0L)
+                .content("modified").anonymity(false).parentCommentId(null).build();
+            given(commentService.updateComment(any(UpdateCommentRequest.class))).willReturn(
+                commentDto);
+            String json = new ObjectMapper().writeValueAsString(request);
+
+            // when, then
+            mockMvc.perform(post("/api/v1/comment/update").content(json)
+                    .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").exists())
+                .andExpect(jsonPath("$.data.postId").exists())
+                .andExpect(jsonPath("$.data.memberId").exists())
+                .andExpect(jsonPath("$.data.content").exists())
+                .andExpect(jsonPath("$.data.anonymity").exists())
+                .andExpect(jsonPath("$.data.parentCommentId").isEmpty()).andDo(print());
+            verify(commentService, times(1)).updateComment(any(UpdateCommentRequest.class));
+        }
+
+        @Nested
+        @DisplayName("id가 ")
+        class Element_id {
+
+            @Test
+            @DisplayName("null일 경우 댓글을 수정할 수 없다.")
+            void null_willFail() throws Exception {
+
+                // given
+                UpdateCommentRequest request = UpdateCommentRequest.builder().id(null)
+                    .content("modified").build();
+                CommentDto commentDto = CommentDto.builder().id(0L).postId(0L).memberId(0L)
+                    .content("test").anonymity(false).parentCommentId(null).build();
+                given(commentService.updateComment(any(UpdateCommentRequest.class))).willReturn(
+                    commentDto);
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(post("/api/v1/comment/update").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                verify(commentService, never()).updateComment(any(UpdateCommentRequest.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("content가 ")
+        class Element_content {
+
+            @Test
+            @DisplayName("null일 경우 댓글을 수정할 수 없다.")
+            void null_willFail() throws Exception {
+
+                // given
+                UpdateCommentRequest request = UpdateCommentRequest.builder().id(0L).content(null)
+                    .build();
+                CommentDto commentDto = CommentDto.builder().id(0L).postId(0L).memberId(0L)
+                    .content("test").anonymity(false).parentCommentId(null).build();
+                given(commentService.updateComment(any(UpdateCommentRequest.class))).willReturn(
+                    commentDto);
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(post("/api/v1/comment/update").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                verify(commentService, never()).updateComment(any(UpdateCommentRequest.class));
+            }
+
+            @Test
+            @DisplayName("빈 칸일 경우 댓글을 수정할 수 없다.")
+            void blank_willFail() throws Exception {
+
+                // given
+                UpdateCommentRequest request = UpdateCommentRequest.builder().id(0L).content(" ")
+                    .build();
+                CommentDto commentDto = CommentDto.builder().id(0L).postId(0L).memberId(0L)
+                    .content("test").anonymity(false).parentCommentId(null).build();
+                given(commentService.updateComment(any(UpdateCommentRequest.class))).willReturn(
+                    commentDto);
+                String json = new ObjectMapper().writeValueAsString(request);
+
+                // when, then
+                mockMvc.perform(post("/api/v1/comment/update").content(json)
+                        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                verify(commentService, never()).updateComment(any(UpdateCommentRequest.class));
+            }
+        }
+    }
+}

--- a/src/test/java/com/fasttime/domain/comment/entity/CommentTest.java
+++ b/src/test/java/com/fasttime/domain/comment/entity/CommentTest.java
@@ -1,0 +1,55 @@
+package com.fasttime.domain.comment.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class CommentTest {
+
+    @DisplayName("댓글을 생성할 수 있다.")
+    @Test
+    void create_comment_willSuccess() {
+        // given
+        String content = "test";
+        boolean anonymity = true;
+
+        // when
+        Comment comment = Comment.builder().post(null).member(null).content(content)
+            .anonymity(anonymity).parentComment(null).build();
+
+        // then
+        assertThat(comment).extracting("content", "anonymity", "parentComment")
+            .containsExactly(content, anonymity, null);
+    }
+
+    @DisplayName("댓글을 수정할 수 있다.")
+    @Test
+    void update_content_willSuccess() {
+        // given
+        Comment comment = Comment.builder().post(null).member(null).content("test").anonymity(true)
+            .parentComment(null).build();
+        String content = "change";
+
+        // when
+        comment.updateContent(content);
+
+        // then
+        assertThat(comment).extracting("content", "anonymity", "parentComment")
+            .containsExactly(content, true, null);
+    }
+
+    @DisplayName("댓글을 삭제할 수 있다.")
+    @Test
+    void delete_comment_willSuccess() {
+        // given
+        Comment comment = Comment.builder().post(null).member(null).content("test").anonymity(true)
+            .parentComment(null).build();
+
+        // when
+        comment.deleteComment();
+
+        // then
+        assertThat(comment.getDeletedAt()).isNotNull();
+    }
+}

--- a/src/test/java/com/fasttime/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/fasttime/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,375 @@
+package com.fasttime.domain.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasttime.domain.comment.dto.CommentDto;
+import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
+import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
+import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;
+import com.fasttime.domain.comment.entity.Comment;
+import com.fasttime.domain.comment.exception.NotFoundException;
+import com.fasttime.domain.comment.repository.CommentRepository;
+import com.fasttime.domain.member.entity.Member;
+import com.fasttime.domain.member.repository.MemberRepository;
+import com.fasttime.domain.post.entity.Post;
+import com.fasttime.domain.post.repository.PostRepository;
+import java.util.Optional;
+import javax.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+public class CommentServiceTest {
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Nested
+    @DisplayName("createComment()는 ")
+    class Context_createComment {
+
+        @Test
+        @DisplayName("비익명으로 댓글을 등록할 수 있다.")
+        void nonAnonymous_willSuccess() {
+            // given
+            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
+                .content("test").anonymity(false).parentCommentId(null).build();
+            Optional<Post> post = Optional.of(Post.builder().id(0L).build());
+            Optional<Member> member = Optional.of(Member.builder().id(0L).build());
+            Comment comment = Comment.builder().id(0L).post(post.get()).member(member.get())
+                .content("test").anonymity(false).parentComment(null).build();
+
+            given(postRepository.findById(any(Long.class))).willReturn(post);
+            given(memberRepository.findById(any(Long.class))).willReturn(member);
+            given(commentRepository.save(any(Comment.class))).willReturn(comment);
+
+            // when
+            CommentDto CommentDto = commentService.createComment(request);
+
+            // then
+            assertThat(CommentDto).extracting("id", "postId", "memberId", "content", "anonymity",
+                "parentCommentId").containsExactly(0L, 0L, 0L, "test", false, null);
+            verify(postRepository, times(1)).findById(any(Long.class));
+            verify(memberRepository, times(1)).findById(any(Long.class));
+            verify(commentRepository, never()).findById(any(Long.class));
+            verify(commentRepository, times(1)).save(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("익명으로 댓글을 등록할 수 있다.")
+        void anonymousComment_willSuccess() {
+            // given
+            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
+                .content("test").anonymity(true).parentCommentId(null).build();
+            Optional<Post> post = Optional.of(Post.builder().id(0L).build());
+            Optional<Member> member = Optional.of(Member.builder().id(0L).build());
+            Comment comment = Comment.builder().id(0L).post(post.get()).member(member.get())
+                .content("test").anonymity(true).parentComment(null).build();
+
+            given(postRepository.findById(any(Long.class))).willReturn(post);
+            given(memberRepository.findById(any(Long.class))).willReturn(member);
+            given(commentRepository.save(any(Comment.class))).willReturn(comment);
+
+            // when
+            CommentDto CommentDto = commentService.createComment(request);
+
+            // then
+            assertThat(CommentDto).extracting("id", "postId", "memberId", "content", "anonymity",
+                "parentCommentId").containsExactly(0L, 0L, 0L, "test", true, null);
+            verify(postRepository, times(1)).findById(any(Long.class));
+            verify(memberRepository, times(1)).findById(any(Long.class));
+            verify(commentRepository, never()).findById(any(Long.class));
+            verify(commentRepository, times(1)).save(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("비익명으로 대댓글을 등록할 수 있다.")
+        void nonAnonymousReply_willSuccess() {
+            // given
+            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
+                .content("test").anonymity(false).parentCommentId(0L).build();
+            Optional<Post> post = Optional.of(Post.builder().id(0L).build());
+            Optional<Member> member = Optional.of(Member.builder().id(0L).build());
+            Optional<Comment> parentComment = Optional.of(
+                Comment.builder().id(0L).post(post.get()).member(member.get()).content("test")
+                    .anonymity(false).parentComment(null).build());
+            Comment comment = Comment.builder().id(1L).post(post.get()).member(member.get())
+                .content("test").anonymity(false).parentComment(parentComment.get()).build();
+
+            given(commentRepository.findById(any(Long.class))).willReturn(parentComment);
+            given(postRepository.findById(any(Long.class))).willReturn(post);
+            given(memberRepository.findById(any(Long.class))).willReturn(member);
+            given(commentRepository.save(any(Comment.class))).willReturn(comment);
+            // when
+            CommentDto CommentDto = commentService.createComment(request);
+
+            // then
+            assertThat(CommentDto).extracting("id", "postId", "memberId", "content", "anonymity",
+                "parentCommentId").containsExactly(1L, 0L, 0L, "test", false, 0L);
+            verify(postRepository, times(1)).findById(any(Long.class));
+            verify(memberRepository, times(1)).findById(any(Long.class));
+            verify(commentRepository, times(1)).findById(any(Long.class));
+            verify(commentRepository, times(1)).save(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("익명으로 대댓글을 등록할 수 있다.")
+        void anonymousReply_willSuccess() {
+            // given
+            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
+                .content("test").anonymity(true).parentCommentId(0L).build();
+            Optional<Post> post = Optional.of(Post.builder().id(0L).build());
+            Optional<Member> member = Optional.of(Member.builder().id(0L).build());
+            Optional<Comment> parentComment = Optional.of(
+                Comment.builder().id(0L).post(post.get()).member(member.get()).content("test")
+                    .anonymity(false).parentComment(null).build());
+            Comment comment = Comment.builder().id(1L).post(post.get()).member(member.get())
+                .content("test").anonymity(true).parentComment(parentComment.get()).build();
+
+            given(commentRepository.findById(any(Long.class))).willReturn(parentComment);
+            given(postRepository.findById(any(Long.class))).willReturn(post);
+            given(memberRepository.findById(any(Long.class))).willReturn(member);
+            given(commentRepository.save(any(Comment.class))).willReturn(comment);
+
+            // when
+            CommentDto CommentDto = commentService.createComment(request);
+
+            // then
+            assertThat(CommentDto).extracting("id", "postId", "memberId", "content", "anonymity",
+                "parentCommentId").containsExactly(1L, 0L, 0L, "test", true, 0L);
+            verify(postRepository, times(1)).findById(any(Long.class));
+            verify(memberRepository, times(1)).findById(any(Long.class));
+            verify(commentRepository, times(1)).findById(any(Long.class));
+            verify(commentRepository, times(1)).save(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("게시물을 찾을 수 없으면 댓글을 등록할 수 없다.")
+        void postNotFound_willFail() {
+            // given
+            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
+                .content("test").anonymity(false).parentCommentId(null).build();
+            Optional<Post> post = Optional.empty();
+
+            given(postRepository.findById(any(Long.class))).willReturn(post);
+
+            // when, then
+            Throwable exception = assertThrows(NotFoundException.class, () -> {
+                commentService.createComment(request);
+            });
+            assertEquals("존재하지 않는 게시글입니다.", exception.getMessage());
+
+            verify(postRepository, times(1)).findById(any(Long.class));
+            verify(commentRepository, never()).findById(any(Long.class));
+            verify(commentRepository, never()).save(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("회원을 찾을 수 없으면 댓글을 등록할 수 없다.")
+        void memberNotFound_willFail() {
+            // given
+            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
+                .content("test").anonymity(false).parentCommentId(null).build();
+            Optional<Post> post = Optional.of(Post.builder().id(0L).build());
+            Optional<Member> member = Optional.of(Member.builder().id(0L).build());
+            member = Optional.empty();
+
+            given(postRepository.findById(any(Long.class))).willReturn(post);
+            given(memberRepository.findById(any(Long.class))).willReturn(member);
+
+            // when, then
+            Throwable exception = assertThrows(NotFoundException.class, () -> {
+                commentService.createComment(request);
+            });
+            assertEquals("존재하지 않는 회원입니다.", exception.getMessage());
+
+            verify(postRepository, times(1)).findById(any(Long.class));
+            verify(memberRepository, times(1)).findById(any(Long.class));
+            verify(commentRepository, never()).findById(any(Long.class));
+            verify(commentRepository, never()).save(any(Comment.class));
+        }
+
+        @Test
+        @DisplayName("댓글을 찾을 수 없으면 대댓글을 등록할 수 없다.")
+        void parentCommentNotFound_willFail() {
+            // given
+            CreateCommentRequest request = CreateCommentRequest.builder().postId(0L).memberId(0L)
+                .content("test").anonymity(false).parentCommentId(0L).build();
+            Optional<Post> post = Optional.of(Post.builder().id(0L).build());
+            Optional<Member> member = Optional.of(Member.builder().id(0L).build());
+            Optional<Comment> parentComment = Optional.empty();
+
+            given(postRepository.findById(any(Long.class))).willReturn(post);
+            given(memberRepository.findById(any(Long.class))).willReturn(member);
+            given(commentRepository.findById(any(Long.class))).willReturn(parentComment);
+
+            // when, then
+            Throwable exception = assertThrows(NotFoundException.class, () -> {
+                commentService.createComment(request);
+            });
+            assertEquals("존재하지 않는 댓글입니다.", exception.getMessage());
+
+            verify(postRepository, times(1)).findById(any(Long.class));
+            verify(memberRepository, times(1)).findById(any(Long.class));
+            verify(commentRepository, times(1)).findById(any(Long.class));
+            verify(commentRepository, never()).save(any(Comment.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getComment()는 ")
+    class Context_getComment {
+
+        @Test
+        @DisplayName("댓글을 가져올 수 있다.")
+        void _willSuccess() {
+            // given
+            Post post = Post.builder().id(0L).build();
+            Member member = Member.builder().id(0L).build();
+            Optional<Comment> comment = Optional.of(
+                Comment.builder().id(0L).post(post).member(member).content("test").anonymity(false)
+                    .parentComment(null).build());
+
+            given(commentRepository.findById(any(Long.class))).willReturn(comment);
+
+            // when
+            CommentDto CommentDto = commentService.getComment(0L);
+
+            // then
+            assertThat(CommentDto).extracting("id", "postId", "memberId", "content", "anonymity",
+                "parentCommentId").containsExactly(0L, 0L, 0L, "test", false, null);
+            verify(commentRepository, times(1)).findById(any(Long.class));
+        }
+
+        @Test
+        @DisplayName("댓글을 찾을 수 없으면 댓글을 가져올 수 없다.")
+        void CommentNotFound_willFail() {
+            // given
+            Optional<Comment> comment = Optional.empty();
+
+            given(commentRepository.findById(any(Long.class))).willReturn(comment);
+
+            // when, then
+            Throwable exception = assertThrows(NotFoundException.class, () -> {
+                commentService.getComment(0L);
+            });
+            assertEquals("존재하지 않는 댓글입니다.", exception.getMessage());
+
+            verify(commentRepository, times(1)).findById(any(Long.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("updateComment()는 ")
+    class Context_updateComment {
+
+        @Test
+        @DisplayName("댓글을 수정할 수 있다.")
+        void _willSuccess() {
+            // given
+            UpdateCommentRequest request = UpdateCommentRequest.builder().id(0L).content("modified")
+                .build();
+            Post post = Post.builder().id(0L).build();
+            Member member = Member.builder().id(0L).build();
+            Optional<Comment> comment = Optional.of(
+                Comment.builder().id(0L).post(post).member(member).content("test").anonymity(false)
+                    .parentComment(null).build());
+
+            given(commentRepository.findById(any(Long.class))).willReturn(comment);
+
+            // when
+            CommentDto CommentDto = commentService.updateComment(request);
+
+            // then
+            assertThat(CommentDto).extracting("id", "postId", "memberId", "content", "anonymity",
+                "parentCommentId").containsExactly(0L, 0L, 0L, "modified", false, null);
+            verify(commentRepository, times(1)).findById(any(Long.class));
+        }
+
+        @Test
+        @DisplayName("댓글을 찾을 수 없으면 댓글을 가져올 수 없다.")
+        void CommentNotFound_willFail() {
+            // given
+            UpdateCommentRequest request = UpdateCommentRequest.builder().id(0L).content("modified")
+                .build();
+            Optional<Comment> comment = Optional.empty();
+
+            given(commentRepository.findById(any(Long.class))).willReturn(comment);
+
+            // when, then
+            Throwable exception = assertThrows(NotFoundException.class, () -> {
+                commentService.updateComment(request);
+            });
+            assertEquals("존재하지 않는 댓글입니다.", exception.getMessage());
+
+            verify(commentRepository, times(1)).findById(any(Long.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteComment()는 ")
+    class Context_deleteComment {
+
+        @Test
+        @DisplayName("댓글을 삭제할 수 있다.")
+        void _willSuccess() {
+            // given
+            DeleteCommentRequest request = DeleteCommentRequest.builder().id(0L).build();
+            Post post = Post.builder().id(0L).build();
+            Member member = Member.builder().id(0L).build();
+            Optional<Comment> comment = Optional.of(
+                Comment.builder().id(0L).post(post).member(member).content("test").anonymity(false)
+                    .parentComment(null).build());
+
+            given(commentRepository.findById(any(Long.class))).willReturn(comment);
+
+            // when
+            CommentDto CommentDto = commentService.deleteComment(request);
+
+            // then
+            assertThat(CommentDto).extracting("id", "postId", "memberId", "content", "anonymity",
+                "parentCommentId").containsExactly(0L, 0L, 0L, "test", false, null);
+            verify(commentRepository, times(1)).findById(any(Long.class));
+        }
+
+        @Test
+        @DisplayName("댓글을 찾을 수 없으면 댓글을 삭제할 수 없다.")
+        void CommentNotFound_willFail() {
+            // given
+            DeleteCommentRequest request = DeleteCommentRequest.builder().id(0L).build();
+            Optional<Comment> comment = Optional.empty();
+
+            given(commentRepository.findById(any(Long.class))).willReturn(comment);
+
+            // when, then
+            Throwable exception = assertThrows(NotFoundException.class, () -> {
+                commentService.deleteComment(request);
+            });
+            assertEquals("존재하지 않는 댓글입니다.", exception.getMessage());
+
+            verify(commentRepository, times(1)).findById(any(Long.class));
+        }
+    }
+}


### PR DESCRIPTION
# 댓글 등록, 수정, 삭제 기능 구현

## 내용
- 게시글에 비익명, 익명으로 댓글을 등록할 수 있다. 
- 댓글에 비익명, 익명으로 대댓글을 등록할 수 있다. 
- 댓글 내용을 수정할 수 있다. 
- 댓글을 삭제(SOFT DELETE)할 수 있다. 
- 댓글 ID를 이용해 댓글 정보를 조회할 수 있다. 
- 등록, 수정, 삭제 요청에 대해 Validation 검증이 이뤄진다. 
- 엔터티, 서비스, 컨트롤러 각 기능을 테스트 코드를 통해 테스트할 수 있다. 

---

## 그 외
- 게시글과 회원 정보를 불러오는 작업은 해당하는 각 도메인 서비스에 구현된 기능을 사용하도록 수정할 계획입니다. 
- 회원 정보 조회 시 엔터티에 맞게 Long 자료형을 사용하도록 MemberRepository 수정이 필요할 것 같습니다. @ghrltjdtprbs 확인 부탁드립니다. 