### PR TITLE
댓글 컨트롤러에서 ResponseDTO를 사용하도록 수정

### DIFF
--- a/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentRestController.java
@@ -4,8 +4,7 @@ import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
 import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
 import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;
 import com.fasttime.domain.comment.service.CommentService;
-import java.util.HashMap;
-import java.util.Map;
+import com.fasttime.global.util.ResponseDTO;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,33 +24,29 @@ public class CommentRestController {
     private final CommentService commentService;
 
     @PostMapping("/create")
-    public ResponseEntity<Map<String, Object>> create(
+    public ResponseEntity<ResponseDTO> create(
         @Valid @RequestBody CreateCommentRequest createCommentRequest) {
         log.info("CreateCommentRequest: " + createCommentRequest);
-        Map<String, Object> message = new HashMap<>();
-        message.put("status", 201);
-        message.put("data", commentService.createComment(createCommentRequest));
-
-        return ResponseEntity.status(HttpStatus.CREATED).body(message);
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            ResponseDTO.res(HttpStatus.CREATED, "댓글을 성공적으로 등록했습니다.",
+                commentService.createComment(createCommentRequest)));
     }
 
     @PostMapping("/delete")
-    public ResponseEntity<Map<String, Object>> delete(
+    public ResponseEntity<ResponseDTO> delete(
         @Valid @RequestBody DeleteCommentRequest deleteCommentRequest) {
         log.info("DeleteCommentRequest: " + deleteCommentRequest);
-        Map<String, Object> message = new HashMap<>();
-        message.put("status", 200);
-        message.put("data", commentService.deleteComment(deleteCommentRequest));
-        return ResponseEntity.status(HttpStatus.OK).body(message);
+        return ResponseEntity.status(HttpStatus.OK).body(
+            ResponseDTO.res(HttpStatus.OK, "댓글을 성공적으로 삭제했습니다.",
+                commentService.deleteComment(deleteCommentRequest)));
     }
 
     @PostMapping("/update")
-    public ResponseEntity<Map<String, Object>> update(
+    public ResponseEntity<ResponseDTO> update(
         @Valid @RequestBody UpdateCommentRequest updateCommentRequest) {
         log.info("UpdateCommentRequest: " + updateCommentRequest);
-        Map<String, Object> message = new HashMap<>();
-        message.put("status", 200);
-        message.put("data", commentService.updateComment(updateCommentRequest));
-        return ResponseEntity.status(HttpStatus.OK).body(message);
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseDTO.res(HttpStatus.OK, "댓글 내용을 성공적으로 수정했습니다.",
+                commentService.updateComment(updateCommentRequest)));
     }
 }

--- a/src/main/java/com/fasttime/domain/comment/controller/CommentRestControllerAdvice.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentRestControllerAdvice.java
@@ -1,11 +1,11 @@
 package com.fasttime.domain.comment.controller;
 
 import com.fasttime.domain.comment.exception.NotFoundException;
+import com.fasttime.global.util.ResponseDTO;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -18,21 +18,16 @@ public class CommentRestControllerAdvice {
     @ExceptionHandler
     public ResponseEntity<?> notFoundException(NotFoundException e) {
         log.error("NotFoundException: " + e.getMessage());
-        Map<String, Object> errorMessage = new HashMap<>();
-        errorMessage.put("status", 404);
-        errorMessage.put("error", e.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(MediaType.APPLICATION_JSON)
-            .body(errorMessage);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ResponseDTO.res(HttpStatus.NOT_FOUND, e.getMessage()));
     }
 
     @ExceptionHandler
     public ResponseEntity<?> bindException(BindException e) {
         log.error("BindException: " + e.getMessage());
-        Map<String, Object> errorMessage = new HashMap<>();
-        errorMessage.put("status", 400);
-        errorMessage.put("error", e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(MediaType.APPLICATION_JSON)
-            .body(errorMessage);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+            ResponseDTO.res(HttpStatus.BAD_REQUEST,
+                e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
     }
 
     @ExceptionHandler
@@ -41,7 +36,7 @@ public class CommentRestControllerAdvice {
         Map<String, Object> errorMessage = new HashMap<>();
         errorMessage.put("status", 400);
         errorMessage.put("error", e.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(MediaType.APPLICATION_JSON)
-            .body(errorMessage);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDTO.res(HttpStatus.BAD_REQUEST, e.getMessage()));
     }
 }

--- a/src/test/java/com/fasttime/domain/comment/controller/CommentRestControllerTest.java
+++ b/src/test/java/com/fasttime/domain/comment/controller/CommentRestControllerTest.java
@@ -83,7 +83,7 @@ public class CommentRestControllerTest {
                 // when, then
                 mockMvc.perform(post("/api/v1/comment/create").content(json)
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
                 verify(commentService, never()).createComment(any(CreateCommentRequest.class));
             }
         }
@@ -108,7 +108,7 @@ public class CommentRestControllerTest {
                 // when, then
                 mockMvc.perform(post("/api/v1/comment/create").content(json)
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
                 verify(commentService, never()).createComment(any(CreateCommentRequest.class));
             }
         }
@@ -133,7 +133,7 @@ public class CommentRestControllerTest {
                 // whCreate
                 mockMvc.perform(post("/api/v1/comment/create").content(json)
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
                 verify(commentService, never()).createComment(any(CreateCommentRequest.class));
             }
 
@@ -153,7 +153,7 @@ public class CommentRestControllerTest {
                 // when, then
                 mockMvc.perform(post("/api/v1/comment/create").content(json)
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
                 verify(commentService, never()).createComment(any(CreateCommentRequest.class));
             }
         }
@@ -178,7 +178,7 @@ public class CommentRestControllerTest {
                 // when, then
                 mockMvc.perform(post("/api/v1/comment/create").content(json)
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
                 verify(commentService, never()).createComment(any(CreateCommentRequest.class));
             }
         }
@@ -231,7 +231,7 @@ public class CommentRestControllerTest {
                 // when, then
                 mockMvc.perform(post("/api/v1/comment/delete").content(json)
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
                 verify(commentService, never()).deleteComment(any(DeleteCommentRequest.class));
             }
         }
@@ -286,7 +286,7 @@ public class CommentRestControllerTest {
                 // when, then
                 mockMvc.perform(post("/api/v1/comment/update").content(json)
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
                 verify(commentService, never()).updateComment(any(UpdateCommentRequest.class));
             }
         }
@@ -311,7 +311,7 @@ public class CommentRestControllerTest {
                 // when, then
                 mockMvc.perform(post("/api/v1/comment/update").content(json)
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
                 verify(commentService, never()).updateComment(any(UpdateCommentRequest.class));
             }
 
@@ -331,7 +331,7 @@ public class CommentRestControllerTest {
                 // when, then
                 mockMvc.perform(post("/api/v1/comment/update").content(json)
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.error").exists()).andDo(print());
+                    .andExpect(jsonPath("$.message").exists()).andDo(print());
                 verify(commentService, never()).updateComment(any(UpdateCommentRequest.class));
             }
         }


### PR DESCRIPTION
# 댓글 컨트롤러에서 ResponseDTO를 사용하도록 수정

- 댓글 REST Controller에서 응답 시 ResponseDTO를 사용하도록 수정했습니다. 
- 이에 따라 에러 메시지 또한 ```message```에 담겨 보내지기 때문에 댓글 컨트롤러 테스트 코드를 수정했습니다. 