### PR TITLE
예외처리를 리팩토링 한다.

### DIFF
--- a/src/main/java/com/fasttime/domain/comment/controller/CommentRestControllerAdvice.java
+++ b/src/main/java/com/fasttime/domain/comment/controller/CommentRestControllerAdvice.java
@@ -1,42 +1,10 @@
 package com.fasttime.domain.comment.controller;
 
-import com.fasttime.domain.comment.exception.NotFoundException;
-import com.fasttime.global.util.ResponseDTO;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindException;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice
 public class CommentRestControllerAdvice {
 
-    @ExceptionHandler
-    public ResponseEntity<?> notFoundException(NotFoundException e) {
-        log.error("NotFoundException: " + e.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-            .body(ResponseDTO.res(HttpStatus.NOT_FOUND, e.getMessage()));
-    }
-
-    @ExceptionHandler
-    public ResponseEntity<?> bindException(BindException e) {
-        log.error("BindException: " + e.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-            ResponseDTO.res(HttpStatus.BAD_REQUEST,
-                e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
-    }
-
-    @ExceptionHandler
-    public ResponseEntity<?> illegalArgException(IllegalArgumentException e) {
-        log.error("IllegalArgumentException: " + e.getMessage());
-        Map<String, Object> errorMessage = new HashMap<>();
-        errorMessage.put("status", 400);
-        errorMessage.put("error", e.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ResponseDTO.res(HttpStatus.BAD_REQUEST, e.getMessage()));
-    }
 }

--- a/src/main/java/com/fasttime/domain/comment/exception/CommentNotFoundException.java
+++ b/src/main/java/com/fasttime/domain/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,13 @@
+package com.fasttime.domain.comment.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import org.springframework.http.HttpStatus;
+
+public class CommentNotFoundException extends ApplicationException {
+
+    private static final HttpStatus httpStatus = HttpStatus.NOT_FOUND;
+
+    public CommentNotFoundException() {
+        super(httpStatus, "존재하지 않는 댓글입니다.");
+    }
+}

--- a/src/main/java/com/fasttime/domain/comment/exception/NotFoundException.java
+++ b/src/main/java/com/fasttime/domain/comment/exception/NotFoundException.java
@@ -1,8 +1,0 @@
-package com.fasttime.domain.comment.exception;
-
-public class NotFoundException extends RuntimeException {
-
-    public NotFoundException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/fasttime/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fasttime/domain/comment/service/CommentService.java
@@ -5,11 +5,13 @@ import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
 import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
 import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;
 import com.fasttime.domain.comment.entity.Comment;
-import com.fasttime.domain.comment.exception.NotFoundException;
+import com.fasttime.domain.comment.exception.CommentNotFoundException;
 import com.fasttime.domain.comment.repository.CommentRepository;
 import com.fasttime.domain.member.entity.Member;
+import com.fasttime.domain.member.exception.UserNotFoundException;
 import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.post.entity.Post;
+import com.fasttime.domain.post.exception.PostNotFoundException;
 import com.fasttime.domain.post.repository.PostRepository;
 import java.util.Optional;
 import javax.transaction.Transactional;
@@ -34,15 +36,15 @@ public class CommentService {
         if (req.getParentCommentId() != null) {
             Optional<Comment> Comment = commentRepository.findById(req.getParentCommentId());
             if (Comment.isEmpty()) {
-                throw new NotFoundException("존재하지 않는 댓글입니다.");
+                throw new CommentNotFoundException();
             } else {
                 parentComment = Comment.get();
             }
         }
         if (post.isEmpty()) {
-            throw new NotFoundException("존재하지 않는 게시글입니다.");
+            throw new PostNotFoundException();
         } else if (member.isEmpty()) {
-            throw new NotFoundException("존재하지 않는 회원입니다.");
+            throw new UserNotFoundException();
         } else {
             return commentRepository.save(
                 Comment.builder().post(post.get()).member(member.get()).content(req.getContent())
@@ -53,7 +55,7 @@ public class CommentService {
     public CommentDTO getComment(Long id) {
         Optional<Comment> comment = commentRepository.findById(id);
         if (comment.isEmpty()) {
-            throw new NotFoundException("존재하지 않는 댓글입니다.");
+            throw new CommentNotFoundException();
         } else {
             return comment.get().toDTO();
         }
@@ -62,7 +64,7 @@ public class CommentService {
     public CommentDTO deleteComment(DeleteCommentRequest req) {
         Optional<Comment> comment = commentRepository.findById(req.getId());
         if (comment.isEmpty()) {
-            throw new NotFoundException("존재하지 않는 댓글입니다.");
+            throw new CommentNotFoundException();
         } else {
             comment.get().deleteComment();
             return comment.get().toDTO();
@@ -72,7 +74,7 @@ public class CommentService {
     public CommentDTO updateComment(UpdateCommentRequest req) {
         Optional<Comment> comment = commentRepository.findById(req.getId());
         if (comment.isEmpty()) {
-            throw new NotFoundException("존재하지 않는 댓글입니다.");
+            throw new CommentNotFoundException();
         } else {
             comment.get().updateContent(req.getContent());
         }

--- a/src/main/java/com/fasttime/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fasttime/domain/comment/service/CommentService.java
@@ -44,7 +44,7 @@ public class CommentService {
         if (post.isEmpty()) {
             throw new PostNotFoundException();
         } else if (member.isEmpty()) {
-            throw new UserNotFoundException();
+            throw new UserNotFoundException("존재하지 않는 회원입니다.");
         } else {
             return commentRepository.save(
                 Comment.builder().post(post.get()).member(member.get()).content(req.getContent())

--- a/src/main/java/com/fasttime/domain/member/controller/MemberControllerAdvice.java
+++ b/src/main/java/com/fasttime/domain/member/controller/MemberControllerAdvice.java
@@ -1,42 +1,26 @@
 package com.fasttime.domain.member.controller;
 
-import com.fasttime.domain.member.exception.UserNotFoundException;
 import com.fasttime.global.util.ResponseDTO;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice
+@Slf4j
+@RestControllerAdvice(basePackages = "com.fasttime.domain.member")
 public class MemberControllerAdvice {
 
-    @ExceptionHandler   //검증 실패 예외
-    public ResponseEntity<ResponseDTO> bindException(BindException e) {
-        Map<String, Object> message = new HashMap<>();
-        message.put("error", e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-            ResponseDTO.res(HttpStatus.BAD_REQUEST,
-                e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
-    }
     @ExceptionHandler   // 비밀번호가 틀리거나 비밀번호 재확인이 일치하지않는 예외
-    public ResponseEntity<?> BadCredentialsException(BadCredentialsException e) {
+    public ResponseEntity<ResponseDTO<Object>> badCredentialsException(BadCredentialsException e) {
         Map<String, Object> message = new HashMap<>();
         message.put("error", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .contentType(MediaType.APPLICATION_JSON)
-            .body(message);
-    }
-    @ExceptionHandler //등록되지 않는 이메일로 접근시 발생하는 예외
-    public ResponseEntity<?> UserNotFoundException(UserNotFoundException e) {
-        Map<String, Object> message = new HashMap<>();
-        message.put("error", e.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .contentType(MediaType.APPLICATION_JSON)
-            .body(message);
+            .body(ResponseDTO.res(HttpStatus.BAD_REQUEST, message));
     }
 }

--- a/src/main/java/com/fasttime/domain/member/exception/UserNotFoundException.java
+++ b/src/main/java/com/fasttime/domain/member/exception/UserNotFoundException.java
@@ -1,6 +1,6 @@
 package com.fasttime.domain.member.exception;
 
-public class UserNotFoundException extends Exception {
+public class UserNotFoundException extends RuntimeException {
 
     public UserNotFoundException(String message) {
         super(message);

--- a/src/main/java/com/fasttime/domain/post/exception/NotPostWriterException.java
+++ b/src/main/java/com/fasttime/domain/post/exception/NotPostWriterException.java
@@ -1,0 +1,13 @@
+package com.fasttime.domain.post.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import org.springframework.http.HttpStatus;
+
+public class NotPostWriterException extends ApplicationException {
+
+    private static final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+
+    public NotPostWriterException() {
+        super(httpStatus, "해당 게시글에 대한 권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/fasttime/domain/post/exception/PostNotFoundException.java
+++ b/src/main/java/com/fasttime/domain/post/exception/PostNotFoundException.java
@@ -1,0 +1,13 @@
+package com.fasttime.domain.post.exception;
+
+import com.fasttime.global.exception.ApplicationException;
+import org.springframework.http.HttpStatus;
+
+public class PostNotFoundException extends ApplicationException {
+
+    private static final HttpStatus httpStatus = HttpStatus.NOT_FOUND;
+
+    public PostNotFoundException() {
+        super(httpStatus, "존재하지 않는 게시글입니다.");
+    }
+}

--- a/src/main/java/com/fasttime/domain/post/service/PostCommandService.java
+++ b/src/main/java/com/fasttime/domain/post/service/PostCommandService.java
@@ -4,6 +4,8 @@ import com.fasttime.domain.post.dto.service.request.PostCreateServiceDto;
 import com.fasttime.domain.post.dto.service.request.PostUpdateServiceDto;
 import com.fasttime.domain.post.dto.service.response.PostResponseDto;
 import com.fasttime.domain.post.entity.Post;
+import com.fasttime.domain.post.exception.NotPostWriterException;
+import com.fasttime.domain.post.exception.PostNotFoundException;
 import com.fasttime.domain.post.repository.PostRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,8 +32,7 @@ public class PostCommandService {
 
     public PostResponseDto updatePost(PostUpdateServiceDto serviceDto) {
 
-        Post post = postRepository.findById(serviceDto.getPostId())
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+        Post post = findPostById(serviceDto);
 
         validateMemberAuthority(serviceDto.getMemberId(), post.getMember().getId());
 
@@ -40,9 +41,14 @@ public class PostCommandService {
         return PostResponseDto.of(post);
     }
 
+    private Post findPostById(PostUpdateServiceDto serviceDto) {
+        return postRepository.findById(serviceDto.getPostId())
+            .orElseThrow(PostNotFoundException::new);
+    }
+
     private static void validateMemberAuthority(Long requesterId, Long writerId) {
         if (!requesterId.equals(writerId)) {
-            throw new IllegalArgumentException("해당 게시글에 대한 권한이 없습니다.");
+            throw new NotPostWriterException();
         }
     }
 }

--- a/src/main/java/com/fasttime/global/exception/ApplicationException.java
+++ b/src/main/java/com/fasttime/global/exception/ApplicationException.java
@@ -1,0 +1,15 @@
+package com.fasttime.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ApplicationException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+
+    protected ApplicationException(HttpStatus httpStatus, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/com/fasttime/global/exception/GlobalExceptionRestAdvice.java
+++ b/src/main/java/com/fasttime/global/exception/GlobalExceptionRestAdvice.java
@@ -1,0 +1,39 @@
+package com.fasttime.global.exception;
+
+import com.fasttime.global.util.ResponseDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionRestAdvice {
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDTO<Object>> applicationException(ApplicationException e) {
+        log.error("applicationException: " + e.getMessage());
+        return ResponseEntity
+            .status(e.getHttpStatus())
+            .body(ResponseDTO.res(e.getHttpStatus(), e.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDTO<Object>> bindException(BindException e) {
+        log.error("BindException: " + e.getMessage());
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDTO.res(HttpStatus.BAD_REQUEST,
+                e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ResponseDTO<Object>> serverException(RuntimeException e) {
+        log.error("Server Exception: " + e.getMessage());
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ResponseDTO.res(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러!"));
+    }
+}

--- a/src/main/java/com/fasttime/global/util/ResponseDTO.java
+++ b/src/main/java/com/fasttime/global/util/ResponseDTO.java
@@ -5,25 +5,40 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class ResponseDTO {
+public class ResponseDTO<T> {
 
     private final int code;
     private final String message;
-    private final Object data;
+    private final T data;
 
     @Builder
-    private ResponseDTO(int code, String message, Object data) {
+    private ResponseDTO(int code, String message, T data) {
         this.code = code;
         this.message = message;
         this.data = data;
     }
 
-    public static ResponseDTO res(final HttpStatus httpStatus, final String message) {
-        return ResponseDTO.builder().code(httpStatus.value()).message(message).build();
+    public static ResponseDTO<Object> res(final HttpStatus httpStatus, final String message) {
+        return ResponseDTO.<Object>builder()
+            .code(httpStatus.value())
+            .message(message)
+            .build();
     }
 
-    public static ResponseDTO res(final HttpStatus httpStatus, final String message,
-        final Object object) {
-        return ResponseDTO.builder().code(httpStatus.value()).message(message).data(object).build();
+    public static <T> ResponseDTO<T> res(final HttpStatus httpStatus, final T data) {
+        return ResponseDTO.<T>builder()
+            .code(httpStatus.value())
+            .data(data)
+            .build();
+    }
+
+    public static <T> ResponseDTO<T> res(final HttpStatus httpStatus,
+        final String message,
+        final T data) {
+        return ResponseDTO.<T>builder()
+            .code(httpStatus.value())
+            .message(message)
+            .data(data)
+            .build();
     }
 }

--- a/src/test/java/com/fasttime/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/fasttime/domain/comment/service/CommentServiceTest.java
@@ -14,11 +14,13 @@ import com.fasttime.domain.comment.dto.request.CreateCommentRequest;
 import com.fasttime.domain.comment.dto.request.DeleteCommentRequest;
 import com.fasttime.domain.comment.dto.request.UpdateCommentRequest;
 import com.fasttime.domain.comment.entity.Comment;
-import com.fasttime.domain.comment.exception.NotFoundException;
+import com.fasttime.domain.comment.exception.CommentNotFoundException;
 import com.fasttime.domain.comment.repository.CommentRepository;
 import com.fasttime.domain.member.entity.Member;
+import com.fasttime.domain.member.exception.UserNotFoundException;
 import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.post.entity.Post;
+import com.fasttime.domain.post.exception.PostNotFoundException;
 import com.fasttime.domain.post.repository.PostRepository;
 import java.util.Optional;
 import javax.transaction.Transactional;
@@ -176,7 +178,7 @@ public class CommentServiceTest {
             given(postRepository.findById(any(Long.class))).willReturn(post);
 
             // when, then
-            Throwable exception = assertThrows(NotFoundException.class, () -> {
+            Throwable exception = assertThrows(PostNotFoundException.class, () -> {
                 commentService.createComment(request);
             });
             assertEquals("존재하지 않는 게시글입니다.", exception.getMessage());
@@ -200,7 +202,7 @@ public class CommentServiceTest {
             given(memberRepository.findById(any(Long.class))).willReturn(member);
 
             // when, then
-            Throwable exception = assertThrows(NotFoundException.class, () -> {
+            Throwable exception = assertThrows(UserNotFoundException.class, () -> {
                 commentService.createComment(request);
             });
             assertEquals("존재하지 않는 회원입니다.", exception.getMessage());
@@ -226,7 +228,7 @@ public class CommentServiceTest {
             given(commentRepository.findById(any(Long.class))).willReturn(parentComment);
 
             // when, then
-            Throwable exception = assertThrows(NotFoundException.class, () -> {
+            Throwable exception = assertThrows(CommentNotFoundException.class, () -> {
                 commentService.createComment(request);
             });
             assertEquals("존재하지 않는 댓글입니다.", exception.getMessage());
@@ -272,7 +274,7 @@ public class CommentServiceTest {
             given(commentRepository.findById(any(Long.class))).willReturn(comment);
 
             // when, then
-            Throwable exception = assertThrows(NotFoundException.class, () -> {
+            Throwable exception = assertThrows(CommentNotFoundException.class, () -> {
                 commentService.getComment(0L);
             });
             assertEquals("존재하지 않는 댓글입니다.", exception.getMessage());
@@ -319,7 +321,7 @@ public class CommentServiceTest {
             given(commentRepository.findById(any(Long.class))).willReturn(comment);
 
             // when, then
-            Throwable exception = assertThrows(NotFoundException.class, () -> {
+            Throwable exception = assertThrows(CommentNotFoundException.class, () -> {
                 commentService.updateComment(request);
             });
             assertEquals("존재하지 않는 댓글입니다.", exception.getMessage());
@@ -364,7 +366,7 @@ public class CommentServiceTest {
             given(commentRepository.findById(any(Long.class))).willReturn(comment);
 
             // when, then
-            Throwable exception = assertThrows(NotFoundException.class, () -> {
+            Throwable exception = assertThrows(CommentNotFoundException.class, () -> {
                 commentService.deleteComment(request);
             });
             assertEquals("존재하지 않는 댓글입니다.", exception.getMessage());

--- a/src/test/java/com/fasttime/domain/member/controller/MemberControllerTestForAuto.java
+++ b/src/test/java/com/fasttime/domain/member/controller/MemberControllerTestForAuto.java
@@ -2,36 +2,29 @@ package com.fasttime.domain.member.controller;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasttime.domain.member.dto.request.LoginRequestDTO;
 import com.fasttime.domain.member.dto.MemberDto;
+import com.fasttime.domain.member.dto.request.LoginRequestDTO;
 import com.fasttime.domain.member.request.RePasswordRequest;
 import com.fasttime.domain.member.service.MemberService;
 import com.fasttime.global.interceptor.LoginCheckInterceptor;
-import org.apache.juli.logging.Log;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MockMvcBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -109,7 +102,7 @@ public class MemberControllerTestForAuto {
             mockMvc.perform(post("/v1/login")
                     .content(s)
                     .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.error").exists())
+                .andExpect(jsonPath("$.message").exists())
                 .andDo(print());
         }
         @DisplayName("비밀번호가 달라 실패한다.")
@@ -123,7 +116,7 @@ public class MemberControllerTestForAuto {
             mockMvc.perform(post("/v1/login")
                     .content(s)
                     .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.error").value("Not match password!"))
+                .andExpect(jsonPath("$.data.error").value("Not match password!"))
                 .andDo(print());
         }
 
@@ -206,7 +199,7 @@ public class MemberControllerTestForAuto {
             mockMvc.perform(post("/v1/RePassword")
                     .content(s)
                     .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.error").exists())
+                .andExpect(jsonPath("$.data.error").exists())
                 .andDo(print());
         }
     }


### PR DESCRIPTION
## 내용
* Application 전용 Exception 계층화
* GlobalExceptionAdvice 생성

### Exception 예시
```java
public class PostNotFoundException extends ApplicationException {

    private static final HttpStatus httpStatus = HttpStatus.NOT_FOUND;

    public PostNotFoundException() {
        super(httpStatus, "존재하지 않는 게시글입니다.");
    }
}
``` 
* ApplicationException을 상속한 예외들은 아래의 Advice에서 처리됩니다.
* 예외 생성 시 해당 도메인에 관련 예외를 생성한 후 사용하세요.
* 기존의 예외들은 모두 변경을 실시했습니다.
<br>

### GlobalExcceptionRestAdvice
```java
@Slf4j
@RestControllerAdvice
public class GlobalExceptionRestAdvice {

    @ExceptionHandler
    public ResponseEntity<ResponseDTO<Object>> applicationException(ApplicationException e) {
        log.error("applicationException: " + e.getMessage());
        return ResponseEntity
            .status(e.getHttpStatus())
            .body(ResponseDTO.res(e.getHttpStatus(), e.getMessage()));
    }

    @ExceptionHandler
    public ResponseEntity<ResponseDTO<Object>> bindException(BindException e) {
        log.error("BindException: " + e.getMessage());
        return ResponseEntity
            .status(HttpStatus.BAD_REQUEST)
            .body(ResponseDTO.res(HttpStatus.BAD_REQUEST,
                e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
    }

    @ExceptionHandler
    public ResponseEntity<ResponseDTO<Object>> serverException(RuntimeException e) {
        log.error("Server Exception: " + e.getMessage());
        return ResponseEntity
            .status(HttpStatus.BAD_REQUEST)
            .body(ResponseDTO.res(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러!"));
    }
}
```

<br>
<br>

## 관련 ISSUE
ISSUE #30