### PR TITLE
[refactor] Post Domain Response 재설계

### DIFF
--- a/src/main/java/com/fasttime/domain/post/controller/PostController.java
+++ b/src/main/java/com/fasttime/domain/post/controller/PostController.java
@@ -2,21 +2,20 @@ package com.fasttime.domain.post.controller;
 
 import com.fasttime.domain.post.dto.controller.request.PostCreateRequestDto;
 import com.fasttime.domain.post.dto.service.request.PostCreateServiceDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.service.PostCommandService;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RequestMapping("/api/v1/post")
-@Controller
+@RestController
 public class PostController {
 
     private final PostCommandService postCommandService;
@@ -25,18 +24,15 @@ public class PostController {
         this.postCommandService = postCommandService;
     }
 
-    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
-    public String writePost(@Valid @ModelAttribute PostCreateRequestDto requestDto,
-        Model model,
-        BindingResult bindingResult) {
-        log.info("request :" + requestDto);
-        postCommandService.writePost(
+    public ResponseEntity<PostDetailResponseDto> writePost(@Valid @RequestBody PostCreateRequestDto requestDto) {
+        PostDetailResponseDto postResponseDto = postCommandService.writePost(
             new PostCreateServiceDto(requestDto.getMemberId(),
                 requestDto.getTitle(),
                 requestDto.getContent(),
                 requestDto.isAnonymity()));
 
-        return "post/posts";
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(postResponseDto);
     }
 }

--- a/src/main/java/com/fasttime/domain/post/dto/controller/request/PostCreateRequestDto.java
+++ b/src/main/java/com/fasttime/domain/post/dto/controller/request/PostCreateRequestDto.java
@@ -2,6 +2,7 @@ package com.fasttime.domain.post.dto.controller.request;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
@@ -11,6 +12,7 @@ public class PostCreateRequestDto {
     private final Long memberId;
 
     @NotBlank
+    @Size(min = 5, message = "제목은 5자리 이상이어야 합니다.")
     private final String title;
 
     @NotBlank

--- a/src/main/java/com/fasttime/domain/post/dto/service/response/PostDetailResponseDto.java
+++ b/src/main/java/com/fasttime/domain/post/dto/service/response/PostDetailResponseDto.java
@@ -1,10 +1,10 @@
 package com.fasttime.domain.post.dto.service.response;
 
-import com.fasttime.domain.post.entity.Post;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class PostResponseDto {
+public class PostDetailResponseDto {
 
     private final Long id;
     private final String title;
@@ -13,23 +13,14 @@ public class PostResponseDto {
     private final int likeCount;
     private final int hateCount;
 
-    private PostResponseDto(Long id, String title, String content, boolean anonymity, int likeCount,
-        int hateCount) {
+    @Builder
+    private PostDetailResponseDto(Long id, String title, String content, boolean anonymity,
+        int likeCount, int hateCount) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.anonymity = anonymity;
         this.likeCount = likeCount;
         this.hateCount = hateCount;
-    }
-
-    public static PostResponseDto of(Post post) {
-
-        return new PostResponseDto(post.getId(),
-            post.getTitle(),
-            post.getContent(),
-            post.isAnonymity(),
-            post.getLikeCount(),
-            post.getHateCount());
     }
 }

--- a/src/main/java/com/fasttime/domain/post/dto/service/response/PostsResponseDto.java
+++ b/src/main/java/com/fasttime/domain/post/dto/service/response/PostsResponseDto.java
@@ -1,32 +1,26 @@
 package com.fasttime.domain.post.dto.service.response;
 
-import com.fasttime.domain.post.entity.Post;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class PostListResponseDto {
+public class PostsResponseDto {
 
     private final Long id;
     private final String title;
     private final boolean anonymity;
+    private final int commentCounts;
     private final int likeCount;
     private final int hateCount;
 
-    private PostListResponseDto(Long id, String title, boolean anonymity, int likeCount,
+    @Builder
+    private PostsResponseDto(Long id, String title, boolean anonymity, int commentCounts, int likeCount,
         int hateCount) {
         this.id = id;
         this.title = title;
         this.anonymity = anonymity;
+        this.commentCounts = commentCounts;
         this.likeCount = likeCount;
         this.hateCount = hateCount;
-    }
-
-    public static PostListResponseDto of(Post post) {
-
-        return new PostListResponseDto(post.getId(),
-            post.getTitle(),
-            post.isAnonymity(),
-            post.getLikeCount(),
-            post.getHateCount());
     }
 }

--- a/src/main/java/com/fasttime/domain/post/service/PostCommandService.java
+++ b/src/main/java/com/fasttime/domain/post/service/PostCommandService.java
@@ -6,7 +6,7 @@ import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.post.dto.service.request.PostCreateServiceDto;
 import com.fasttime.domain.post.dto.service.request.PostDeleteServiceDto;
 import com.fasttime.domain.post.dto.service.request.PostUpdateServiceDto;
-import com.fasttime.domain.post.dto.service.response.PostResponseDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.exception.NotPostWriterException;
 import com.fasttime.domain.post.exception.PostNotFoundException;
@@ -26,28 +26,34 @@ public class PostCommandService {
         this.postRepository = postRepository;
     }
 
-    public PostResponseDto writePost(PostCreateServiceDto serviceDto) {
+    public PostDetailResponseDto writePost(PostCreateServiceDto serviceDto) {
 
         Member member = memberRepository.findById(serviceDto.getMemberId())
             .orElseThrow(() -> new UserNotFoundException("회원 정보가 없습니다."));
 
-        Post createdPost = Post.createNewPost(member, serviceDto.getTitle(), serviceDto.getContent(),
+        Post createdPost = Post.createNewPost(member, serviceDto.getTitle(),
+            serviceDto.getContent(),
             false);
 
         Post savedPost = postRepository.save(createdPost);
 
-        return PostResponseDto.of(savedPost);
+        return PostDetailResponseDto.builder()
+            .id(savedPost.getId())
+            .title(savedPost.getTitle())
+            .content(savedPost.getContent())
+            .anonymity(savedPost.isAnonymity())
+            .likeCount(savedPost.getLikeCount())
+            .hateCount(savedPost.getHateCount())
+            .build();
     }
 
-    public PostResponseDto updatePost(PostUpdateServiceDto serviceDto) {
+    public void updatePost(PostUpdateServiceDto serviceDto) {
 
         Post post = findPostById(serviceDto);
 
         validateMemberAuthority(serviceDto.getMemberId(), post.getMember().getId());
 
         post.update(serviceDto.getContent());
-
-        return PostResponseDto.of(post);
     }
 
     public void deletePost(PostDeleteServiceDto serviceDto) {

--- a/src/main/java/com/fasttime/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fasttime/domain/post/service/PostQueryService.java
@@ -1,11 +1,10 @@
 package com.fasttime.domain.post.service;
 
-import com.fasttime.domain.post.dto.service.response.PostListResponseDto;
-import com.fasttime.domain.post.dto.service.response.PostResponseDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
+import com.fasttime.domain.post.dto.service.response.PostsResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.repository.PostRepository;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,17 +19,21 @@ public class PostQueryService {
         this.postRepository = postRepository;
     }
 
-    public PostResponseDto searchById(Long id) {
+    public PostDetailResponseDto searchById(Long id) {
         Post findPost = postRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("게시글이 없습니다."));
 
-        return PostResponseDto.of(findPost);
+        return PostDetailResponseDto.builder()
+            .id(findPost.getId())
+            .title(findPost.getTitle())
+            .content(findPost.getContent())
+            .anonymity(findPost.isAnonymity())
+            .likeCount(findPost.getLikeCount())
+            .hateCount(findPost.getHateCount())
+            .build();
     }
 
-    public List<PostListResponseDto> searchPosts(Pageable pageable) {
-        return postRepository.findAll(pageable)
-            .stream()
-            .map(PostListResponseDto::of)
-            .collect(Collectors.toList());
+    public List<PostsResponseDto> searchPosts(Pageable pageable) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/test/java/com/fasttime/domain/post/unit/service/PostCommandServiceTest.java
+++ b/src/test/java/com/fasttime/domain/post/unit/service/PostCommandServiceTest.java
@@ -12,7 +12,7 @@ import com.fasttime.domain.member.repository.MemberRepository;
 import com.fasttime.domain.post.dto.service.request.PostCreateServiceDto;
 import com.fasttime.domain.post.dto.service.request.PostDeleteServiceDto;
 import com.fasttime.domain.post.dto.service.request.PostUpdateServiceDto;
-import com.fasttime.domain.post.dto.service.response.PostResponseDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.entity.ReportStatus;
 import com.fasttime.domain.post.exception.NotPostWriterException;
@@ -59,7 +59,7 @@ class PostCommandServiceTest {
             given(postRepository.save(any(Post.class))).willReturn(mockPost);
 
             // when
-            PostResponseDto response = postCommandService.writePost(dto);
+            PostDetailResponseDto response = postCommandService.writePost(dto);
 
             // then
             assertThat(response).extracting("id", "title", "content", "anonymity", "likeCount",
@@ -102,12 +102,8 @@ class PostCommandServiceTest {
             given(postRepository.findById(anyLong())).willReturn(Optional.of(mockPost));
 
             // when
-            PostResponseDto response = postCommandService.updatePost(serviceDto);
+            postCommandService.updatePost(serviceDto);
 
-            // then
-            assertThat(response).extracting("id", "title", "content", "anonymity", "likeCount",
-                    "hateCount")
-                .containsExactly(1L, "title", "newContent", true, 0, 0);
         }
 
         @DisplayName("수정할 게시글 정보가 DB에 없는 경우 PostNotFoundException을 던진다.")

--- a/src/test/java/com/fasttime/domain/post/unit/service/PostQueryServiceTest.java
+++ b/src/test/java/com/fasttime/domain/post/unit/service/PostQueryServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
-import com.fasttime.domain.post.dto.service.response.PostResponseDto;
+import com.fasttime.domain.post.dto.service.response.PostDetailResponseDto;
 import com.fasttime.domain.post.entity.Post;
 import com.fasttime.domain.post.repository.PostRepository;
 import com.fasttime.domain.post.service.PostQueryService;
@@ -34,7 +34,7 @@ public class PostQueryServiceTest {
     @Nested
     class Context_searchById {
 
-        @DisplayName("key를 넘기면 PostResponse를 반환한다.")
+        @DisplayName("key를 넘기면 PostDetailResponse를 반환한다.")
         @CsvSource(value = {
             "1, 제목1, 내용1, true, 10, 20",
             "2, 제목2, 내용2, false, 15, 30",
@@ -56,7 +56,7 @@ public class PostQueryServiceTest {
                     .build()));
 
             // when
-            PostResponseDto response = postQueryService.searchById(id);
+            PostDetailResponseDto response = postQueryService.searchById(id);
 
             // then
             assertThat(response)


### PR DESCRIPTION
Motivation:

- 현재 `PostListResponseDto.java`, `PostResponseDto.java`가 있었지만, PostList라는 네이밍이 List 타입의 Dto를 반환하는 것 처럼 느껴집니다. 이에 따라 Renaming이 필요해보입니다.

- Dto 각각 domain class를 받는 정적 팩토리 메서드 `xxxDto of(T t)`를 설계했었습니다. 하지만, 해당 도메인 뿐 아니라 다른 도메인들과 조합이 필요한 경우가 있기 때문에, 이를 제거하고 빌더패턴을 사용하기로 했습니다.

Modification:

- `PostsResponseDto.java` 로 Renaming 하기로 결정했습니다. 이에 따라 `PostResponseDto.java`은 조금 더 명확하게 `PostDetailResponseDto.java` 로 변경하게 되었습니다.